### PR TITLE
feat: from-json and to-json

### DIFF
--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -32,6 +32,7 @@ Fish:
 `,
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
+		Hidden:                true,
 		ValidArgs:             []string{"bash", "zsh", "fish"},
 		Args:                  cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/fromjson.go
+++ b/internal/cmd/fromjson.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	"github.com/caarlos0/tasktimer/internal/model"
+	"github.com/caarlos0/tasktimer/internal/store"
+	"github.com/spf13/cobra"
+)
+
+type fromJSONCmd struct {
+	cmd *cobra.Command
+}
+
+func newFromJSONCmd() *fromJSONCmd {
+	var cmd = &cobra.Command{
+		Use:   "from-json",
+		Short: "Imports a JSON into a project - WARNING: it will wipe the project first, use with care!",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var project = cmd.Parent().Flag("project").Value.String()
+			db, f, err := setup(project)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			defer f.Close()
+
+			input, err := ioutil.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to read %s: %w", args[0], err)
+			}
+
+			var tasks []model.Task
+			if err := json.Unmarshal(input, &tasks); err != nil {
+				return fmt.Errorf("input json is not in the correct format: %w", err)
+			}
+
+			tmp, err := ioutil.TempFile("", "tasktimer-"+project)
+			if err != nil {
+				return fmt.Errorf("failed to create backup file: %w", err)
+			}
+			if _, err := db.Backup(tmp, 0); err != nil {
+				return fmt.Errorf("failed to backup to %s: %w", tmp.Name(), err)
+			}
+
+			log.Printf("backup made to %s\n", tmp.Name())
+
+			if err := db.DropAll(); err != nil {
+				return fmt.Errorf("failed to clear database: %w", err)
+			}
+
+			return store.LoadTasks(db, tasks)
+		},
+	}
+
+	return &fromJSONCmd{cmd: cmd}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -49,7 +49,7 @@ func newRootCmd(version string, exit func(int)) *rootCmd {
 
 	cmd.PersistentFlags().StringVarP(&root.project, "project", "p", "default", "Project name")
 
-	cmd.AddCommand(newRerportCmd().cmd, newCompletionCmd().cmd, newPathsCmd().cmd)
+	cmd.AddCommand(newRerportCmd().cmd, newCompletionCmd().cmd, newPathsCmd().cmd, newToJSONCmd().cmd, newFromJSONCmd().cmd)
 
 	root.cmd = cmd
 	return root

--- a/internal/cmd/tojson.go
+++ b/internal/cmd/tojson.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/caarlos0/tasktimer/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+type toJSONCmd struct {
+	cmd *cobra.Command
+}
+
+func newToJSONCmd() *toJSONCmd {
+	var cmd = &cobra.Command{
+		Use:   "to-json",
+		Short: "Exports the database as JSON",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var project = cmd.Parent().Flag("project").Value.String()
+			db, f, err := setup(project)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			defer f.Close()
+
+			return ui.WriteProjectJSON(db, project, os.Stdout)
+		},
+	}
+
+	return &toJSONCmd{cmd: cmd}
+}

--- a/internal/ui/json.go
+++ b/internal/ui/json.go
@@ -1,0 +1,27 @@
+package ui
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/caarlos0/tasktimer/internal/store"
+	"github.com/dgraph-io/badger/v3"
+)
+
+// WriteProjectJSON writes the project task list in JSON format to the given
+// io.Writer.
+func WriteProjectJSON(db *badger.DB, project string, w io.Writer) error {
+	tasks, err := store.GetTaskList(db)
+	if err != nil {
+		return err
+	}
+
+	bts, err := json.Marshal(tasks)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(bts)
+
+	return err
+}


### PR DESCRIPTION
add 2 new commands:

- `to-json`: exports project as json
- `from-json`: imports a project as json (overriding existing data)

should be useful to edit timers when needed (e.g. forgot to pause a timer or something... or forgot to time something entirely)