### PR TITLE
fix: Error when using EDITOR environment variable with arguments

### DIFF
--- a/internal/cmd/edit.go
+++ b/internal/cmd/edit.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,21 +28,19 @@ func newEditCmd() *editCmd {
 				return err
 			}
 
-			editor := os.Getenv("EDITOR")
-			if editor == "" {
+			editor := strings.Fields(os.Getenv("EDITOR"))
+			if len(editor) == 0 {
 				return fmt.Errorf("no $EDITOR set")
 			}
 
-			log.Printf("%s %s\n", editor, tmp)
-
-			editorArgs := []string{tmp}
-			if strings.ContainsAny(editor, " ") {
-				editorParts := strings.Split(editor, " ")
-				editor = editorParts[0]
-				editorArgs = append(editorArgs, editorParts[1:]...)
+			editorCmd := editor[0]
+			var editorArgs []string
+			if len(editor) > 1 {
+				editorArgs = append(editorArgs, editor[1:]...)
 			}
+			editorArgs = append(editorArgs, tmp)
 
-			edit := exec.Command(editor, editorArgs...)
+			edit := exec.Command(editorCmd, editorArgs...)
 			edit.Stderr = os.Stderr
 			edit.Stdout = os.Stdout
 			edit.Stdin = os.Stdin

--- a/internal/cmd/edit.go
+++ b/internal/cmd/edit.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -34,7 +35,15 @@ func newEditCmd() *editCmd {
 			}
 
 			log.Printf("%s %s\n", editor, tmp)
-			edit := exec.Command(editor, tmp)
+
+			editorArgs := []string{tmp}
+			if strings.ContainsAny(editor, " ") {
+				editorParts := strings.Split(editor, " ")
+				editor = editorParts[0]
+				editorArgs = append(editorArgs, editorParts[1:]...)
+			}
+
+			edit := exec.Command(editor, editorArgs...)
 			edit.Stderr = os.Stderr
 			edit.Stdout = os.Stdout
 			edit.Stdin = os.Stdin


### PR DESCRIPTION
Hello there!
First of all, thanks for this awesome little project :)

# Description
This PR tries to fix the issue of using the `tt edit` command in combination with an `EDITOR` environment variable that consists of a command with arguments.

## Issue

### Example
I am using `EDITOR="code --wait"` as my environment variable for starting Visual Studio Code. Currently, this gives the following output:
```console
❯ export EDITOR="code --wait"
❯ tt edit
Error: exec: "code --wait": executable file not found in $PATH
```

### Reason
The whole string `"code --wait"` is passed to `exec.Command` as the first argument. By documentation, only the command itself should be the first argument of `exec.Command` and any arguments of that command should follow as seperate arguments.

## Solution
If there are any spaces in the environment variable `EDITOR`, the command and it's argument are split into two seperate arguments for `exec.Command`.

In my testing both
```console
❯ export EDITOR="code --wait"
❯ tt edit
```
and
```console
❯ export EDITOR="nano"
❯ tt edit
```
worked fine with the proposed fix.