### PR TITLE
docs: remove starchart.cc embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,6 @@ Depends on the OS, but you can see yours running:
 tt paths
 ```
 
-## Stargazers over time
-
-[![Stargazers over time](https://starchart.cc/caarlos0/tasktimer.svg)](https://starchart.cc/caarlos0/tasktimer)
-
 [Badger]: https://github.com/dgraph-io/badger
 [releases]:  https://github.com/caarlos0/tasktimer/releases
 


### PR DESCRIPTION
`starchart.cc` is rate limited and rendering a broken image in the README, so this removes the embed and its (now-empty) stargazers section.

Refs: https://github.com/caarlos0/starcharts/issues/260
